### PR TITLE
Fixed variable lookup when scope has changed

### DIFF
--- a/lib/PHPPHP/Engine/Executor.php
+++ b/lib/PHPPHP/Engine/Executor.php
@@ -51,7 +51,6 @@ class Executor {
 
     public function execute(OpArray $opArray, array &$symbolTable = array(), FunctionData $function = null, array $args = array(), Zval $result = null) {
         if ($this->shutdown) return;
-        $opArray->registerExecutor($this);
         $scope = new ExecuteData($this, $opArray, $function);
         $scope->arguments = $args;
 
@@ -60,11 +59,14 @@ class Executor {
         }
         $this->stack[] = $scope;
         $this->current = $scope;
+
         if ($symbolTable || $function) {
             $scope->symbolTable =& $symbolTable;
         } else {
             $scope->symbolTable =& $this->executorGlobals->symbolTable;
         }
+
+        $opArray->registerExecutor($this);
 
         while (!$this->shutdown && $scope->opLine) {
             $ret = $scope->opLine->execute($scope);

--- a/lib/PHPPHP/Engine/OpArray.php
+++ b/lib/PHPPHP/Engine/OpArray.php
@@ -20,8 +20,9 @@ class OpArray implements \ArrayAccess, \IteratorAggregate {
     public function registerExecutor(Executor $executor) {
         if (!$this->executor) {
             $this->executor = $executor;
+            $executeData = $executor->getCurrent();
             foreach ($this->compiledVariables as $variable) {
-                $variable->setExecutor($executor);
+                $variable->setExecuteData($executeData);
             }
         }   
     }

--- a/lib/PHPPHP/Engine/Zval/Variable.php
+++ b/lib/PHPPHP/Engine/Zval/Variable.php
@@ -8,19 +8,19 @@ class Variable extends Zval {
 
     protected $name;
     protected $zval;
-    protected $executor;
+    protected $executeData;
 
     public function __construct(Zval $name) {
         $this->name = $name;
     }
 
     public function __call($method, $args) {
-        $this->zval = $this->executor->getCurrent()->fetchVariable($this->name->toString());
+        $this->zval = $this->executeData->fetchVariable($this->name->toString());
         return call_user_func_array(array($this->zval, $method), $args);
     }
 
-    public function setExecutor(\PHPPHP\Engine\Executor $executor) {
-        $this->executor = $executor;
+    public function setExecuteData(\PHPPHP\Engine\ExecuteData $executeData) {
+        $this->executeData = $executeData;
     }
 
     public function getName() {


### PR DESCRIPTION
This fixes fetching the value of a Variable when the current scope is not the scope in which the Variable is declared.

This fixes the following code:

``` php
<?php

function x ($x) {
    var_dump($x);
}

$y = 1;
x($y);
```

tests/lang/022.phpt now passes
tests/lang/static_basic_001.phpt now breaks (but should be fixed separately; this is caused by compiled vars being shared between function calls)
