### PR TITLE
Fixed continue

### DIFF
--- a/lib/PHPPHP/Engine/Compiler.php
+++ b/lib/PHPPHP/Engine/Compiler.php
@@ -247,11 +247,12 @@ class Compiler {
         $this->compileChild($node, 'init');
 
         $this->opArray[] = $stackPushOp = new OpLines\StatementStackPush;
-        $stackPushOp->op1 = $startJumpPos = $this->opArray->getNextOffset();
+        $startJumpPos = $this->opArray->getNextOffset();
         $condPtr = Zval::ptrFactory();
         $this->compileChild($node, 'cond', $condPtr);
         $this->opArray[] = $endJumpOp = new OpLines\JumpIfNot($condPtr);
         $this->compileChild($node, 'stmts');
+        $stackPushOp->op1 = $this->opArray->getNextOffset();
         $this->compileChild($node, 'loop');
         $this->opArray[] = new OpLines\Jump($startJumpPos);
         $stackPushOp->op2 = $endJumpOp->op2 = $this->opArray->getNextOffset();
@@ -425,8 +426,9 @@ class Compiler {
         $op1 = Zval::ptrFactory();
 
         $this->opArray[] = $stackPushOp = new OpLines\StatementStackPush;
-        $stackPushOp->op1 = $startJumpPos = $this->opArray->getNextOffset();
+        $startJumpPos = $this->opArray->getNextOffset();
         $this->compileChild($node, 'stmts');
+        $stackPushOp->op1 = $this->opArray->getNextOffset();
         $this->compileChild($node, 'cond', $op1);
         $this->opArray[] = new OpLines\JumpIf($op1, $startJumpPos);
         $stackPushOp->op2 = $this->opArray->getNextOffset();

--- a/lib/PHPPHP/Engine/OpLines/ContinueOp.php
+++ b/lib/PHPPHP/Engine/OpLines/ContinueOp.php
@@ -12,9 +12,10 @@ class ContinueOp extends \PHPPHP\Engine\OpLine {
         $jump = null;
         for ($i = 0; $i < $num; $i++) {
             $jump = array_pop($data->statementStack);
-            if ($jump && !$jump->startOp) $i--;
+            if ($jump && null === $jump->startOp) $i--;
         }
-        if ($jump && $jump->startOp) {
+        if ($jump && null !== $jump->startOp) {
+            $data->statementStack[] = $jump;
             $data->jump($jump->startOp);
         } else {
             throw new \RuntimeException('continue from without context');


### PR DESCRIPTION
This fixes ContinueOp in some cases:
- made it work when startOp offset is 0
- re-pushes the StructureData in the statementStack after `continue`
- changed the startOp offsets for the `do` and `for` loops
