### PR TITLE
Improved support for obj properties and arrays dimentions

### DIFF
--- a/lib/PHPPHP/Engine/Objects/ClassEntry.php
+++ b/lib/PHPPHP/Engine/Objects/ClassEntry.php
@@ -12,11 +12,13 @@ use PHPPHP\Engine\Zval;
 class ClassEntry
 {
     private $name;
+    private $properties;
     private $methods;
     private $parent;
 
     public function __construct($name, ClassEntry $parent = null)
     {
+        $this->properties = array();
         $this->methods = new FunctionStore;
         $this->name = $name;
         $this->parent = $parent;
@@ -38,6 +40,10 @@ class ClassEntry
         return $this->name;
     }
 
+    public function declareProperty($name, Zval $defaultValue) {
+        $this->properties[$name] = $defaultValue;
+    }
+
     public function getMethodStore() {
         return $this->methods;
     }
@@ -48,6 +54,11 @@ class ClassEntry
 
     public function instantiate(ExecuteData $data, array $properties, array $args = array())
     {
+        $parent = $this;
+        do {
+            $properties = array_merge($parent->properties, $properties);
+        } while ($parent = $parent->parent);
+
         $instance = new ClassInstance($this, $properties);
         $instance->callConstructor($data, $args);
         return $instance;

--- a/lib/PHPPHP/Engine/OpLines/Assign.php
+++ b/lib/PHPPHP/Engine/OpLines/Assign.php
@@ -2,16 +2,10 @@
 
 namespace PHPPHP\Engine\OpLines;
 
-class Assign extends \PHPPHP\Engine\OpLine {
+class Assign extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op2->getZval());
-
-        if ($this->result) {
-            $this->result->setValue($this->op2->getZval());
-        }
-
+        $this->setValue($this->op2->getZval());
         $data->nextOp();
     }
-
 }

--- a/lib/PHPPHP/Engine/OpLines/AssignAdd.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignAdd.php
@@ -4,12 +4,10 @@ namespace PHPPHP\Engine\OpLines;
 
 use PHPPHP\Engine\Zval;
 
-class AssignAdd extends \PHPPHP\Engine\OpLine {
+class AssignAdd extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op1->getValue() + $this->op2->getValue());
-        $this->result->setValue($this->op1->getZval());
-
+        $this->setValue($this->getValue() + $this->op2->getValue());
         $data->nextOp();
     }
 

--- a/lib/PHPPHP/Engine/OpLines/AssignBitwiseAnd.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignBitwiseAnd.php
@@ -2,12 +2,10 @@
 
 namespace PHPPHP\Engine\OpLines;
 
-class AssignBitwiseAnd extends \PHPPHP\Engine\OpLine {
+class AssignBitwiseAnd extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op1->getValue() & $this->op2->getValue());
-        $this->result->setValue($this->op1->getZval());
-
+        $this->setValue($this->getValue() & $this->op2->getValue());
         $data->nextOp();
     }
 

--- a/lib/PHPPHP/Engine/OpLines/AssignBitwiseOr.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignBitwiseOr.php
@@ -2,12 +2,10 @@
 
 namespace PHPPHP\Engine\OpLines;
 
-class AssignBitwiseOr extends \PHPPHP\Engine\OpLine {
+class AssignBitwiseOr extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op1->getValue() | $this->op2->getValue());
-        $this->result->setValue($this->op1->getZval());
-
+        $this->setValue($this->getValue() | $this->op2->getValue());
         $data->nextOp();
     }
 

--- a/lib/PHPPHP/Engine/OpLines/AssignBitwiseXor.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignBitwiseXor.php
@@ -2,12 +2,10 @@
 
 namespace PHPPHP\Engine\OpLines;
 
-class AssignBitwiseXor extends \PHPPHP\Engine\OpLine {
+class AssignBitwiseXor extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op1->getValue() ^ $this->op2->getValue());
-        $this->result->setValue($this->op1->getZval());
-
+        $this->setValue($this->getValue() ^ $this->op2->getValue());
         $data->nextOp();
     }
 

--- a/lib/PHPPHP/Engine/OpLines/AssignConcat.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignConcat.php
@@ -4,14 +4,10 @@ namespace PHPPHP\Engine\OpLines;
 
 use PHPPHP\Engine\Zval;
 
-class AssignConcat extends \PHPPHP\Engine\OpLine {
+class AssignConcat extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op1->getValue() . $this->op2->getValue());
-        if ($this->result) {
-            $this->result->setValue($this->op1);
-        }
-
+        $this->setValue($this->getValue() . $this->op2->getValue());
         $data->nextOp();
     }
 

--- a/lib/PHPPHP/Engine/OpLines/AssignDiv.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignDiv.php
@@ -4,15 +4,15 @@ namespace PHPPHP\Engine\OpLines;
 
 use PHPPHP\Engine\Zval;
 
-class AssignDiv extends \PHPPHP\Engine\OpLine {
+class AssignDiv extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        if (0 == $this->op2->getValue()) {
-            $this->op1->setValue(false);
+        $value = $this->getValue();
+        if (0 == $value) {
+            $this->setValue(false);
         } else {
-            $this->op1->setValue($this->op1->getValue() / $this->op2->getValue());
+            $this->setValue($value / $this->op2->getValue());
         }
-        $this->result->setValue($this->op1->getZval());
 
         $data->nextOp();
     }

--- a/lib/PHPPHP/Engine/OpLines/AssignMod.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignMod.php
@@ -2,12 +2,10 @@
 
 namespace PHPPHP\Engine\OpLines;
 
-class AssignMod extends \PHPPHP\Engine\OpLine {
+class AssignMod extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op1->getValue() % $this->op2->getValue());
-        $this->result->setValue($this->op1->getZval());
-
+        $this->setValue($this->getValue() % $this->op2->getValue());
         $data->nextOp();
     }
 

--- a/lib/PHPPHP/Engine/OpLines/AssignMul.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignMul.php
@@ -4,12 +4,10 @@ namespace PHPPHP\Engine\OpLines;
 
 use PHPPHP\Engine\Zval;
 
-class AssignMul extends \PHPPHP\Engine\OpLine {
+class AssignMul extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op1->getValue() * $this->op2->getValue());
-        $this->result->setValue($this->op1->getZval());
-
+        $this->setValue($this->getValue() * $this->op2->getValue());
         $data->nextOp();
     }
 

--- a/lib/PHPPHP/Engine/OpLines/AssignRef.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignRef.php
@@ -4,12 +4,31 @@ namespace PHPPHP\Engine\OpLines;
 
 class AssignRef extends \PHPPHP\Engine\OpLine {
 
+    public $property;
+    public $dim;
+
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
         $this->op2->makeRef();
-        $this->op1->forceValue($this->op2->getZval());
+        $zval = $this->op2->getZval();
+
+        if ($this->property) {
+            $this->op1->getValue()->setProperty($this->property->toString(), $zval);
+
+        } else if ($this->dim) {
+            $array =& $this->op1->getArray();
+            $key = $this->property->toString();
+            if (isset($array[$key])) {
+                $array[$key]->forceValue($zval);
+            } else {
+                $array[$key] = Zval::ptrFactory($zval);
+            }
+
+        } else {
+            $this->op1->forceValue($zval);
+        }
 
         if ($this->result) {
-            $this->result->setValue($this->op2->getValue());
+            $this->result->setValue($zval);
         }
 
         $data->nextOp();

--- a/lib/PHPPHP/Engine/OpLines/AssignShiftLeft.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignShiftLeft.php
@@ -2,12 +2,10 @@
 
 namespace PHPPHP\Engine\OpLines;
 
-class AssignShiftLeft extends \PHPPHP\Engine\OpLine {
+class AssignShiftLeft extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op1->getValue() << $this->op2->getValue());
-        $this->result->setValue($this->op1->getZval());
-
+        $this->setValue($this->getValue() << $this->op2->getValue());
         $data->nextOp();
     }
 

--- a/lib/PHPPHP/Engine/OpLines/AssignShiftRight.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignShiftRight.php
@@ -2,12 +2,10 @@
 
 namespace PHPPHP\Engine\OpLines;
 
-class AssignShiftRight extends \PHPPHP\Engine\OpLine {
+class AssignShiftRight extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op1->getValue() >> $this->op2->getValue());
-        $this->result->setValue($this->op1->getZval());
-
+        $this->setValue($this->getValue() >> $this->op2->getValue());
         $data->nextOp();
     }
 

--- a/lib/PHPPHP/Engine/OpLines/AssignSub.php
+++ b/lib/PHPPHP/Engine/OpLines/AssignSub.php
@@ -4,12 +4,10 @@ namespace PHPPHP\Engine\OpLines;
 
 use PHPPHP\Engine\Zval;
 
-class AssignSub extends \PHPPHP\Engine\OpLine {
+class AssignSub extends BinaryAssign {
 
     public function execute(\PHPPHP\Engine\ExecuteData $data) {
-        $this->op1->setValue($this->op1->getValue() - $this->op2->getValue());
-        $this->result->setValue($this->op1->getZval());
-
+        $this->setValue($this->getValue() - $this->op2->getValue());
         $data->nextOp();
     }
 

--- a/lib/PHPPHP/Engine/OpLines/BinaryAssign.php
+++ b/lib/PHPPHP/Engine/OpLines/BinaryAssign.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PHPPHP\Engine\OpLines;
+
+use PHPPHP\Engine\Zval;
+
+abstract class BinaryAssign extends \PHPPHP\Engine\OpLine {
+
+    public $dim;
+    public $property;
+
+    protected function getValue() {
+
+        if ($this->property) {
+            if (!$this->op1->isObject()) {
+                throw new \RuntimeException('Attempt to assign property of non-object');
+            }
+            return $this->op1->getValue()->getProperty($this->property->toString())->getValue();
+
+        } else if ($this->dim) {
+            $array = $this->op1->getArray();
+            return $array[$this->dim->toString()]->getValue();
+
+        } else {
+            return $this->op1->getValue();
+        }
+    }
+
+    protected function setValue($value) {
+
+        $zval = Zval::factory($value);
+
+        if ($this->property) {
+            $this->op1->getValue()->setProperty($this->property->toString(), $zval);
+
+        } else if ($this->dim) {
+            $array =& $this->op1->getArray();
+            $key = $this->dim->toString();
+            if (isset($array[$key])) {
+                $array[$key]->setValue($zval);
+            } else {
+                $array[$key] = Zval::ptrFactory($zval);
+            }
+
+        } else {
+            $this->op1->setValue($zval);
+        }
+
+        if ($this->result) {
+            $this->result->setValue($zval);
+        }
+    }
+}

--- a/lib/PHPPHP/Engine/Zval/Ptr.php
+++ b/lib/PHPPHP/Engine/Zval/Ptr.php
@@ -10,6 +10,7 @@ class Ptr extends Zval {
 
     public function __construct(Value $zval) {
         $this->zval = $zval;
+        $zval->addRef();
     }
 
     public function __destruct() {
@@ -50,6 +51,10 @@ class Ptr extends Zval {
             $tmp = $value->getZval();
         } while ($value !== $tmp);
         return $value;
+    }
+
+    public function getImmediateZval() {
+        return $this->zval;
     }
 
     public function makeRef() {

--- a/lib/PHPPHP/Engine/Zval/Value.php
+++ b/lib/PHPPHP/Engine/Zval/Value.php
@@ -162,7 +162,7 @@ class Value extends Zval {
             return $this->value;
         } else {
             if ($this->isArray()) {
-                $properties = $this;
+                $properties = $this->value;
             } else {
                 $properties = array(
                     'scalar' => Zval::ptrFactory($this->value),


### PR DESCRIPTION
Added support for defining default obj property values, assigning obj
properties and assigning array dimensions:

```
class C {
    public $foo = "bar";
}
```

```
$o->foo = 1;
$o->foo += 2;
$o['foo'] .= "test";
```

References don't work properly on properties / dimensions yet
