### PR TITLE
fix php.sh to support double quotes

### DIFF
--- a/php.sh
+++ b/php.sh
@@ -1,7 +1,2 @@
 #!/bin/bash
-PARAMS=""
-for PARAM in "$@"
-do
-    PARAMS="${PARAMS} \"${PARAM}\""
-done
-bash -c "php php.php ${PARAMS}"
+php php.php "$@"


### PR DESCRIPTION
The current script loses double quotes, meaning this will fail:

```
$ ./php.sh -r 'var_dump("hello");'
```

I was not sure if there was a reason for the `-c` subshell. Hence the PR. If that needs to stay, an alternate fix would be:

```
PARAMS="${PARAMS} \"${PARAM//\"/\\\"}\""
```

(from [here](http://stackoverflow.com/questions/1668649/how-to-keep-quotes-in-args), lol bash)
