### PR TITLE
Concrete dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,21 +4,21 @@
             "type": "package",
             "package": {
                 "name": "php/php-src",
-                "version": "dev-master",
+                "version": "5.3.20",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/php/php-src",
-                    "reference": "master"
+                    "reference": "php-5.3.20"
                 }
             }
         }
     ],
     "require": {
         "php": ">=5.3.0",
-        "nikic/php-parser": "dev-master"
+        "nikic/php-parser": "v0.9.4"
     },
     "require-dev": {
-        "php/php-src": "dev-master"
+        "php/php-src": "5.3.20"
     },
     "autoload": {
         "psr-0": {"PHPPHP": "lib/"}

--- a/composer.lock
+++ b/composer.lock
@@ -1,30 +1,40 @@
 {
-    "hash": "f0ee609f3432252c6d3294f592159a73",
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "81885b44f7ecfb22d1e445042e8cfe9c",
     "packages": [
         {
             "name": "nikic/php-parser",
-            "version": "dev-master",
+            "version": "v0.9.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser",
-                "reference": "222c9612ab9c65551b7febd38cbb0fa685b0e0db"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "1e5e280ae88a27effa2ae4aa2bd088494ed8594f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/nikic/PHP-Parser/archive/222c9612ab9c65551b7febd38cbb0fa685b0e0db.zip",
-                "reference": "222c9612ab9c65551b7febd38cbb0fa685b0e0db",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1e5e280ae88a27effa2ae4aa2bd088494ed8594f",
+                "reference": "1e5e280ae88a27effa2ae4aa2bd088494ed8594f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.2"
             },
             "type": "library",
-            "installation-source": "source",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.9-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "PHPParser": "lib/"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -35,19 +45,31 @@
             ],
             "description": "A PHP parser written in PHP",
             "keywords": [
-                "php",
-                "parser"
+                "parser",
+                "php"
             ],
-            "time": "1356092915"
+            "time": "2013-08-25T17:11:40+00:00"
         }
     ],
-    "packages-dev": null,
-    "aliases": [
-
+    "packages-dev": [
+        {
+            "name": "php/php-src",
+            "version": "5.3.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php/php-src",
+                "reference": "php-5.3.20"
+            },
+            "type": "library"
+        }
     ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "nikic/php-parser": 20,
-        "php/php-src": 20
-    }
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
 }


### PR DESCRIPTION
I have added concrete dependency versions and updated `composer.lock`.
Version numbers based on last commits date to `PHPPHP` project, reflected to `nikic/php-parser` and `php/php-src` versions at approximately same date. 

Related PR https://github.com/ircmaxell/PHPPHP/pull/29